### PR TITLE
[QMS-624] fix BRouter mutex threading issues

### DIFF
--- a/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.cpp
@@ -185,7 +185,6 @@ void CRouterBRouter::slotCloseStatusMsg() const {
   timerCloseStatusMsg->stop();
   CCanvas* canvas = CMainWindow::self().getVisibleCanvas();
   if (canvas) {
-    canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawGis);
     canvas->reportStatus("BRouter", "");
   }
 }
@@ -446,7 +445,6 @@ void CRouterBRouter::calcRoute(const IGisItem::key_t& key) {
 
   CCanvas* canvas = CMainWindow::self().getVisibleCanvas();
   if (canvas) {
-    canvas->slotTriggerCompleteUpdate(CCanvas::eRedrawGis);
     canvas->reportStatus("BRouter", tr("<b>BRouter</b><br/>Routing request sent to server. Please wait..."));
   }
 

--- a/src/qmapshack/gis/rte/router/CRouterBRouter.h
+++ b/src/qmapshack/gis/rte/router/CRouterBRouter.h
@@ -51,6 +51,9 @@ class CRouterBRouter : public IRouter, private Ui::IRouterBRouter {
 
   void setupLocalDir(QString localDir);
 
+ signals:
+  void sigCancelRouting();
+
  public slots:
   void slotToolSetupClicked();
 
@@ -79,8 +82,8 @@ class CRouterBRouter : public IRouter, private Ui::IRouterBRouter {
 
   QNetworkAccessManager* networkAccessManager;
   QTimer* timerCloseStatusMsg;
-  bool synchronous = false;
-  QMutex mutex;
+  bool isCalculating{false};
+  QTimer* timerSynchronousRequest;
   CRouterBRouterSetup* setup;
   CRouterSetup* routerSetup;
   CRouterBRouterInfo* info;

--- a/src/qmapshack/gis/rte/router/brouter/CRouterBRouterLocal.cpp
+++ b/src/qmapshack/gis/rte/router/brouter/CRouterBRouterLocal.cpp
@@ -90,8 +90,7 @@ void CRouterBRouterLocal::startBRouter() {
 
   while (timer.remainingTime() > 0 && brouterState == QProcess::Running) {
     socket.connectToHost(brouter.setup->localHost, brouter.setup->localPort.toInt());
-    // Processing userinputevents in local eventloop would cause a SEGV when clicking 'abort' of calling LineOp
-    connectState = connect_state_e(eventLoop->exec(QEventLoop::ExcludeUserInputEvents));
+    connectState = connect_state_e(eventLoop->exec(QEventLoop::AllEvents));
 
     // retry after 100ms, but only in case socket is not yet connectable
     if (connectState == eError && socketError == QAbstractSocket::ConnectionRefusedError) {


### PR DESCRIPTION
### What is the linked issue for this pull request:

QMS-#624

### What you have done:

replaced the mutex-protected field 'synchronous' by a reply-property that doesn't require to be protected as qt takes care when delivering via signal.

### Steps to perform a simple smoke test:
[comment]: # N/A, you cannot see the difference in the ui

### Does the code comply to the coding rules and naming conventions [Coding Guidelines](https://github.com/Maproom/qmapshack/wiki/DeveloperCodingGuideline):

- [X] yes

### Is every user facing string in a tr() macro?

- [X] yes

### Did you add the ticket number and title into the changelog? Keep the numeric order in each release block.

- [ ] N/A as I'm raising this PR against existing PR #629 which would be included in the changelog.txt
